### PR TITLE
Remove phpunit whitelist option from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ php:
 
 install: travis_retry composer install --no-interaction --prefer-source
 
-script: vendor/bin/phpunit tests --coverage-clover clover.xml --whitelist src
+script: vendor/bin/phpunit tests --coverage-clover clover.xml
 
 after_script: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The whitelist is already defined in the phpunit.xml file (loaded with `--configuration phpunit.xml`).